### PR TITLE
予測モデルの結果を元にパターン購入するモデルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# dorper
+
+## how to start
+
+1. get database
+
+1. ```python extract_feature.py```
+2. ```python income_predict2.py```
+
+## how to create features
+
+inherit base.py and override extract_feature method.

--- a/create_index.py
+++ b/create_index.py
@@ -7,3 +7,10 @@ engine = create_engine('sqlite:///race_database_new.sqlite3')
 from models import RaceResult
 race_result_index = Index('race_result_index_with_pitout_lane', RaceResult.year, RaceResult.racer_id, RaceResult.pitout_lane)
 race_result_index.create(bind=engine)
+
+# %%
+from models import RaceOdds
+race_odds_index = Index('race_odds_index', RaceOdds.year, RaceOdds.race_num)
+race_odds_index.create(bind=engine)
+
+# %%

--- a/extract_features.py
+++ b/extract_features.py
@@ -10,6 +10,10 @@ valid_race_result_list_17 = session.query(RaceInfo, RaceResultGrouped)\
     .join(RaceInfo, RaceInfo.race_num==RaceResultGrouped.race_num)\
     .filter(RaceInfo.year==RaceResultGrouped.year, RaceInfo.year==2017,\
     RaceInfo.is_race_no_flying==1, RaceInfo.is_race_times_record_valid==1).all()
+valid_race_result_list_18 = session.query(RaceInfo, RaceResultGrouped)\
+    .join(RaceInfo, RaceInfo.race_num==RaceResultGrouped.race_num)\
+    .filter(RaceInfo.year==RaceResultGrouped.year, RaceInfo.year==2018,\
+    RaceInfo.is_race_no_flying==1, RaceInfo.is_race_times_record_valid==1).all()
 # valid_race_info_list_17 = session.query(RaceInfo, RaceResultGrouped)\
 #     .filter(RaceInfo.year==2017, RaceInfo.is_race_no_flying==1, RaceInfo.is_race_times_record_valid==1).all()
 
@@ -31,3 +35,11 @@ from feature.racer_win_rate_year import RacerInfoWinRateYear
 racer_win_rate_period = RacerInfoWinRateYear(race_info_list=valid_race_result_list_17, year=2017)
 racer_win_rate_period.extract_feature()
 racer_win_rate_period.save('./feature_pkls/racer_win_rate_year_2017.pkl')
+
+#%%
+from feature.race_odds_year_validated import RaceOddsYearValidated
+race_odds_year_validated18 = RaceOddsYearValidated(race_info_list=valid_race_result_list_18, year=2018)
+race_odds_year_validated18.extract_feature()
+race_odds_year_validated18.save('./feature_pkls/race_odds_year_validated_2018.pkl')
+
+# %%

--- a/extract_features.py
+++ b/extract_features.py
@@ -31,4 +31,3 @@ from feature.racer_win_rate_year import RacerInfoWinRateYear
 racer_win_rate_period = RacerInfoWinRateYear(race_info_list=valid_race_result_list_17, year=2017)
 racer_win_rate_period.extract_feature()
 racer_win_rate_period.save('./feature_pkls/racer_win_rate_year_2017.pkl')
-

--- a/feature/join.py
+++ b/feature/join.py
@@ -27,7 +27,7 @@ class Join:
                 feature_concatenated = np.concatenate([feature_concatenated, np.array(single_feature_list)])
 
             if self.group_features_dic_list or self.single_features_dic_list:
-                self.feature_list.append(feature_concatenated)
+                self.feature_list.append(feature_concatenated[0])
 
     def get_feature_list(self):
         return self.feature_list

--- a/feature/race_odds_year_validated.py
+++ b/feature/race_odds_year_validated.py
@@ -1,0 +1,30 @@
+import sys
+import numpy as np
+
+from .base import BaseFeature
+from models import RaceOdds, RaceInfo
+
+#parent directory
+sys.path.append('..')
+from utils.setting import session
+
+class RaceOddsYearValidated(BaseFeature):
+
+    def __init__(self, race_info_list=None, year=None, *args, **kwargs):
+        super().__init__()
+        self.race_info_list = race_info_list
+        self.year = year
+        self.data_dic = {}
+
+    def extract_feature(self):
+        self.data_dic = {}
+        for race_info_grouped in self.race_info_list:
+            race_odds = session.query(RaceOdds).filter(RaceOdds.year==self.year,\
+                        RaceOdds.race_num==race_info_grouped.RaceResultGrouped.race_num).first()
+            if race_odds:
+                data = {'result':[race_odds.rank1_lane, race_odds.rank2_lane, race_odds.rank3_lane],\
+                        'tanshou': race_odds.tanshou, 'sanrentan': race_odds.sanrentan}
+                self.data_dic[race_info_grouped.RaceResultGrouped.race_num] = data
+
+    def get_feature(self):
+        return self.data_dic

--- a/income_predict2.py
+++ b/income_predict2.py
@@ -1,0 +1,88 @@
+# %%
+from sqlalchemy.sql import text
+
+from sklearn.model_selection import KFold
+from sklearn.ensemble import RandomForestClassifier
+from sklearn import metrics
+
+import numpy as np
+
+from models import RaceResult, RacerInfo, RaceResultGrouped, RaceInfo
+from utils.setting import session
+from utils.data import load_data
+
+# %%
+session.rollback()
+
+# %%
+import lightgbm as lgb
+
+from feature.join import Join
+from feature.race_result_ranks_one_hot import RaceResultRanksOneHot
+from feature.race_odds_year_validated import RaceOddsYearValidated
+
+# %%
+# data loaading
+simple_feature17_obj = Join()
+simple_feature17_obj.load('feature_pkls/simple_feature_17.pkl')
+simple_feature17 = simple_feature17_obj.get_feature_list()
+
+race_result_ranks_one_hot_17_all = RaceResultRanksOneHot()
+race_result_ranks_one_hot_17_all.load('feature_pkls/race_result_ranks_one_hot_2017_all.pkl')
+label17 = race_result_ranks_one_hot_17_all.get_feature()
+label_list17 = [label17[key] for key in label17.keys()]
+
+simple_feature18_obj = Join()
+simple_feature18_obj.load('feature_pkls/simple_feature_18.pkl')
+simple_feature18 = simple_feature18_obj.get_feature_list()
+
+race_result_ranks_one_hot_18_all = RaceResultRanksOneHot()
+race_result_ranks_one_hot_18_all.load('feature_pkls/race_result_ranks_one_hot_2018_all.pkl')
+label18 = race_result_ranks_one_hot_18_all.get_feature()
+label_list18 = [label18[key] for key in label18.keys()]
+
+race_odds_year_validated18 = RaceOddsYearValidated()
+race_odds_year_validated18.load('feature_pkls/race_odds_year_validated_2018.pkl')
+race_odds_year_validated18_dic = race_odds_year_validated18.get_feature()
+
+# %%
+from sklearn.ensemble import RandomForestRegressor
+from utils.util import onehot2rank
+
+# train
+
+# lgb_train = lgb.Dataset(np.array(simple_feature17), np.ones(len(label17)))
+# lgbm_params = {
+#     'objective': 'regression'
+# }
+
+# model = lgb.train(lgbm_params, lgb_train)
+model = RandomForestRegressor()
+model.fit(simple_feature17, label_list17)
+predicted_res = model.predict(simple_feature18)
+predicted_res_onehot = [onehot2rank(predicted_res[idx]) for idx in range(len(predicted_res))]
+
+# %%
+from utils.purchase_pattern import get_sanrentan_nagashi_222_pattern
+valid_race_result_list_18 = session.query(RaceInfo, RaceResultGrouped)\
+    .join(RaceInfo, RaceInfo.race_num==RaceResultGrouped.race_num)\
+    .filter(RaceInfo.year==RaceResultGrouped.year, RaceInfo.year==2018,\
+    RaceInfo.is_race_no_flying==1, RaceInfo.is_race_times_record_valid==1).all()
+
+payment = 0
+revenue = 0
+hit = 0
+for idx, (predicted_res, label, key) in enumerate(zip(predicted_res_onehot, label_list18, race_odds_year_validated18_dic.keys())):
+    rank_label = onehot2rank(label)
+    label_top3_lane = [rank_label.index(1)+1, rank_label.index(2)+1, rank_label.index(3)+1]
+    sanrentan_pattern = get_sanrentan_nagashi_222_pattern(predicted_res)
+    sanrentan_odds = race_odds_year_validated18_dic[key]['sanrentan']
+    if sanrentan_odds:
+        if label_top3_lane in sanrentan_pattern:
+            revenue += sanrentan_odds
+            hit += 1
+        payment += len(sanrentan_pattern) * 100
+
+
+
+# %%

--- a/join_features.py
+++ b/join_features.py
@@ -6,30 +6,29 @@ session.rollback()
 
 # %%
 
-valid_race_result_list_17 = session.query(RaceInfo, RaceResultGrouped)\
+valid_race_result_list_18 = session.query(RaceInfo, RaceResultGrouped)\
     .join(RaceInfo, RaceInfo.race_num==RaceResultGrouped.race_num)\
-    .filter(RaceInfo.year==RaceResultGrouped.year, RaceInfo.year==2017,\
+    .filter(RaceInfo.year==RaceResultGrouped.year, RaceInfo.year==2018,\
     RaceInfo.is_race_no_flying==1, RaceInfo.is_race_times_record_valid==1).all()
 
 #%%
 from feature.racer_win_rate_year import RacerInfoWinRateYear
 from feature.racer_info_base import RacerInfoBase
 from utils.pickle_helper import pickle_load
-racer_info_base_2017 = RacerInfoBase()
-racer_info_base_2017.load('feature_pkls/racer_win_rate_year_2017.pkl')
-race_win_rate_year_2017 = RacerInfoWinRateYear()
-race_win_rate_year_2017.load('feature_pkls/racer_win_rate_year_2017.pkl')
+racer_info_base_2018 = RacerInfoBase()
+racer_info_base_2018.load('feature_pkls/racer_win_rate_year_2018.pkl')
+race_win_rate_year_2018 = RacerInfoWinRateYear()
+race_win_rate_year_2018.load('feature_pkls/racer_win_rate_year_2018.pkl')
 
 #%%
 from feature.join import Join
-race_id_list = [ race.RaceInfo.race_num for race in valid_race_result_list_17]
+race_id_list = [race.RaceInfo.race_num for race in valid_race_result_list_18]
 
-group_feature_dic_list = [racer_info_base_2017.get_feature(),\
-                          race_win_rate_year_2017.get_feature()]
-simple_feature_17 = Join(id_list=race_id_list,\
+group_feature_dic_list = [racer_info_base_2018.get_feature(),\
+                          race_win_rate_year_2018.get_feature()]
+simple_feature_18 = Join(id_list=race_id_list,\
                          group_features_dic_list=group_feature_dic_list)
-simple_feature_17.join_feature()
-simple_feature_17.save('feature_pkls/simple_feature_17.pkl')
-
+simple_feature_18.join_feature()
+simple_feature_18.save('feature_pkls/simple_feature_18.pkl')
 
 #%%

--- a/utils/data.py
+++ b/utils/data.py
@@ -4,7 +4,7 @@ from sqlalchemy.sql import text
 from sqlalchemy import case, cast, func, Float
 
 from models import RaceResult, RacerInfo, RaceOdds, RaceInfo, RaceResultGrouped
-from setting import session
+from .setting import session
 from collections import namedtuple
 
 rank_dic = {1:150, 2:100, 3:50, 4:0}

--- a/utils/income_metrics.py
+++ b/utils/income_metrics.py
@@ -1,5 +1,6 @@
 from itertools import permutations, combinations
 
+# 各選手のレーンごとの予想勝率を元に収益を計算
 def get_lane_win_prob(racer_win_prob, lane, rank):
     return racer_win_prob[lane*6+rank]
 

--- a/utils/purchase_pattern.py
+++ b/utils/purchase_pattern.py
@@ -1,0 +1,46 @@
+from itertools import permutations, combinations
+
+# 三連単の購入パターン
+
+## 1位1人，2位1人，3位2人の組み合わせ
+def get_sanrentan_nagashi_112_pattern(pred_result):
+    pass
+
+## 1,2位2人，3位4人の組み合わせ
+def get_nagashi_22all_pattern(pred_result):
+    purchase_patterns = []
+    top2_lane_list = [pred_result.index(1), pred_result.index(2)]
+    top2_patterns = list(permutations(top2_lane_list))
+    lower4_lane_list = [pred_result.index(3), pred_result.index(4),\
+                       pred_result.index(5), pred_result.index(6)]
+    lower4_patterns = list(combinations(lower4_lane_list, 1))
+    for top2_pattern in top2_patterns:
+        for lower4_pattern in lower4_patterns:
+            purchase_patterns.append(list(top2_pattern).extend(list(lower4_pattern)))
+
+    return purchase_patterns
+
+## 1,2位2人，3位2人の組み合わせ
+def get_sanrentan_nagashi_222_pattern(pred_result):
+    purchase_patterns = []
+    top2_lane_list = [pred_result.index(1)+1, pred_result.index(2)+1]
+    top2_patterns = list(permutations(top2_lane_list))
+    lower2_lane_list = [pred_result.index(3)+1, pred_result.index(4)+1]
+    lower2_patterns = list(combinations(lower2_lane_list, 1))
+    for top2_pattern in top2_patterns:
+        for lower2_pattern in lower2_patterns:
+            top2_pattern_list = list(top2_pattern)
+            top2_pattern_list.extend(list(lower2_pattern))
+            purchase_patterns.append(top2_pattern_list)
+
+    return purchase_patterns
+
+## 上位n人の組み合わせを全て購入
+def get_sanrentan_boxn_pattern(pred_result, n=3):
+    topn_lane_list = []
+    for i in range(n):
+        topn_lane_list.append(pred_result.index(i+1))
+    topn_permutation = list(permutations(topn_lane_list))
+    purchase_patterns = list(map(lambda x: list(x[:3]), topn_permutation))
+
+    return purchase_patterns


### PR DESCRIPTION
- Random Forestによる回帰によって得たランクづけを元に https://boat-race.biz/738 のパターンを購入する．
- 現状試したパターンは，予測モデルによるランクが1,2の選手を1,2位におくパターン，3,4の選手を3位におくパターンを組み合わせた計4パターンを購入するもの
- 特徴が正しく取れているかなどについては未検証だが，150%程度の回収率